### PR TITLE
Feature/update upload url

### DIFF
--- a/server/services/publish/publishFormat.js
+++ b/server/services/publish/publishFormat.js
@@ -6,7 +6,7 @@ class PublishFormat {
       storage: 'disk',
       publishDir: '/static/publishes',
       uploadDir: 'static/uploads',
-      host: 'https://cie.arc.cubeapis.com'
+      host: 'https://rcmcashcontent.org'
     }
 
     this._options = Object.assign({}, defaults, options)

--- a/server/services/publish/publishFormat.js
+++ b/server/services/publish/publishFormat.js
@@ -5,7 +5,7 @@ class PublishFormat {
       type: 'file',
       storage: 'disk',
       publishDir: '/static/publishes',
-      uploadDir: 'uploads',
+      uploadDir: 'static/uploads',
       host: 'https://cie.arc.cubeapis.com'
     }
 


### PR DESCRIPTION
This PR tackles issue #20 

The Bound DMS, when doing a publish will create a bundle. Within that bundle URLs are created that point towards the files on each directory.

This was using the default upload dir of `uploads`, the bound dms actually uploads them to `static/uploads`

https://github.com/AmericanRedCross/bound-dms/blob/e672d8efb14b92aa88a876e00b05ce1ef3326ed6/server/services/publish/bundleArchive.js#L48

I have updated publishFormat.js (the publish service that runs the publishing) to represent this and tested on the ARC CIE iOS and Android clients.



There will be PRs coming your way for both of these clients as we have some minor updates that should improve reliability.

